### PR TITLE
Enable sending spans in zipkin v2 formats

### DIFF
--- a/api/bazel/repositories.bzl
+++ b/api/bazel/repositories.bzl
@@ -31,6 +31,11 @@ def api_dependencies():
         locations = REPOSITORY_LOCATIONS,
         build_file_content = OPENCENSUSTRACE_BUILD_CONTENT,
     )
+    envoy_http_archive(
+        name = "com_github_apache_zipkinapi",
+        locations = REPOSITORY_LOCATIONS,
+        build_file_content = ZIPKINAPI_BUILD_CONTENT,
+    )
 
 GOOGLEAPIS_BUILD_CONTENT = """
 load("@com_google_protobuf//:protobuf.bzl", "cc_proto_library", "py_proto_library")
@@ -282,6 +287,26 @@ go_proto_library(
     name = "trace_model_go_proto",
     importpath = "trace_model",
     proto = ":trace_model",
+    visibility = ["//visibility:public"],
+)
+"""
+
+ZIPKINAPI_BUILD_CONTENT = """
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+api_proto_library(
+    name = "zipkin",
+    srcs = [
+        "zipkin.proto",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "zipkin_go_proto",
+    importpath = "zipkin",
+    proto = ":zipkin",
     visibility = ["//visibility:public"],
 )
 """

--- a/api/bazel/repository_locations.bzl
+++ b/api/bazel/repository_locations.bzl
@@ -10,6 +10,9 @@ OPENCENSUS_SHA256 = "4fd21cc6de63d7cb979fd749d8101ff425905aa0826fed26019d1c311fc
 PGV_RELEASE = "0.0.13"
 PGV_SHA256 = "dce6c8a43849d2abe4d5e40f16e9a476bca6b7a47e128db4458a52d748f4a5eb"
 
+ZIPKINAPI_RELEASE = "0.2.0"
+ZIPKINAPI_SHA256 = "cc34d57c51a52e8b9ea8ea5ca51e25016531eabc6c47be9b11d8fc29a5d266ae"
+
 GOOGLEAPIS_GIT_SHA = "d642131a6e6582fc226caf9893cb7fe7885b3411"  # May 23, 2018
 GOOGLEAPIS_SHA = "16f5b2e8bf1e747a32f9a62e211f8f33c94645492e9bbd72458061d9a9de1f63"
 
@@ -47,5 +50,10 @@ REPOSITORY_LOCATIONS = dict(
         sha256 = OPENCENSUS_SHA256,
         strip_prefix = "opencensus-proto-" + OPENCENSUS_RELEASE + "/src/opencensus/proto/trace/v1",
         urls = ["https://github.com/census-instrumentation/opencensus-proto/archive/v" + OPENCENSUS_RELEASE + ".tar.gz"],
+    ),
+    com_github_apache_zipkinapi = dict(
+        sha256 = ZIPKINAPI_SHA256,
+        strip_prefix = "incubator-zipkin-api-" + ZIPKINAPI_RELEASE,
+        urls = ["https://github.com/apache/incubator-zipkin-api/archive/" + ZIPKINAPI_RELEASE + ".tar.gz"],
     ),
 )

--- a/api/envoy/config/trace/v2/trace.proto
+++ b/api/envoy/config/trace/v2/trace.proto
@@ -80,6 +80,16 @@ message ZipkinConfig {
   // Determines whether client and server spans will shared the same span id.
   // The default value is true.
   google.protobuf.BoolValue shared_span_context = 4;
+
+  // Zipkin collector endpoint version.
+  enum CollectorEndpointVersion {
+    HTTP_JSON_V1 = 0;
+    HTTP_JSON = 1;
+    HTTP_PROTO = 2;
+  }
+
+  // Determines the current version.
+  CollectorEndpointVersion collector_endpoint_version = 6;
 }
 
 // DynamicOtConfig is used to dynamically load a tracer from a shared library

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -129,6 +129,7 @@ public:
     const std::string GrpcWebText{"application/grpc-web-text"};
     const std::string GrpcWebTextProto{"application/grpc-web-text+proto"};
     const std::string Json{"application/json"};
+    const std::string Proto{"application/x-protobuf"};
   } ContentTypeValues;
 
   struct {

--- a/source/extensions/tracers/zipkin/BUILD
+++ b/source/extensions/tracers/zipkin/BUILD
@@ -54,9 +54,11 @@ envoy_cc_library(
         "//source/common/http:utility_lib",
         "//source/common/json:json_loader_lib",
         "//source/common/network:address_lib",
+        "//source/common/protobuf:utility_lib",
         "//source/common/singleton:const_singleton",
         "//source/common/tracing:http_tracer_lib",
         "//source/extensions/tracers:well_known_names",
+        "@com_github_apache_zipkinapi//:zipkin_cc",
     ],
 )
 

--- a/source/extensions/tracers/zipkin/span_buffer.cc
+++ b/source/extensions/tracers/zipkin/span_buffer.cc
@@ -1,5 +1,7 @@
 #include "extensions/tracers/zipkin/span_buffer.h"
 
+#include "zipkin.pb.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace Tracers {
@@ -14,6 +16,17 @@ bool SpanBuffer::addSpan(const Span& span) {
   span_buffer_.push_back(std::move(span));
 
   return true;
+}
+
+const zipkin::proto3::ListOfSpans SpanBuffer::toProto() {
+  zipkin::proto3::ListOfSpans spans;
+  if (pendingSpans()) {
+    for (const auto& span : span_buffer_) {
+      auto* mutable_span = spans.add_spans();
+      mutable_span->MergeFrom(span.toProto());
+    }
+  }
+  return spans;
 }
 
 std::string SpanBuffer::toStringifiedJsonArray() {

--- a/source/extensions/tracers/zipkin/span_buffer.cc
+++ b/source/extensions/tracers/zipkin/span_buffer.cc
@@ -20,11 +20,11 @@ std::string SpanBuffer::toStringifiedJsonArray() {
   std::string stringified_json_array = "[";
 
   if (pendingSpans()) {
-    stringified_json_array += span_buffer_[0].toJson();
+    stringified_json_array += span_buffer_[0].toJson(version_);
     const uint64_t size = span_buffer_.size();
     for (uint64_t i = 1; i < size; i++) {
       stringified_json_array += ",";
-      stringified_json_array += span_buffer_[i].toJson();
+      stringified_json_array += span_buffer_[i].toJson(version_);
     }
   }
   stringified_json_array += "]";

--- a/source/extensions/tracers/zipkin/span_buffer.h
+++ b/source/extensions/tracers/zipkin/span_buffer.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "envoy/config/trace/v2/trace.pb.h"
+
 #include "extensions/tracers/zipkin/zipkin_core_types.h"
 
 namespace Envoy {
@@ -17,14 +19,19 @@ public:
    * Constructor that creates an empty buffer. Space needs to be allocated by invoking
    * the method allocateBuffer(size).
    */
-  SpanBuffer() {}
+  SpanBuffer(const envoy::config::trace::v2::ZipkinConfig::CollectorEndpointVersion version)
+      : version_(version) {}
 
   /**
    * Constructor that initializes a buffer with the given size.
    *
    * @param size The desired buffer size.
    */
-  SpanBuffer(uint64_t size) { allocateBuffer(size); }
+  SpanBuffer(const envoy::config::trace::v2::ZipkinConfig::CollectorEndpointVersion version,
+             uint64_t size)
+      : version_(version) {
+    allocateBuffer(size);
+  }
 
   /**
    * Allocates space for an empty buffer or resizes a previously-allocated one.
@@ -62,6 +69,7 @@ public:
 private:
   // We use a pre-allocated vector to improve performance
   std::vector<Span> span_buffer_;
+  const envoy::config::trace::v2::ZipkinConfig::CollectorEndpointVersion version_;
 };
 
 } // namespace Zipkin

--- a/source/extensions/tracers/zipkin/span_buffer.h
+++ b/source/extensions/tracers/zipkin/span_buffer.h
@@ -66,6 +66,10 @@ public:
    */
   std::string toStringifiedJsonArray();
 
+  const zipkin::proto3::ListOfSpans toProto();
+
+  envoy::config::trace::v2::ZipkinConfig::CollectorEndpointVersion version() { return version_; }
+
 private:
   // We use a pre-allocated vector to improve performance
   std::vector<Span> span_buffer_;

--- a/source/extensions/tracers/zipkin/zipkin_core_types.cc
+++ b/source/extensions/tracers/zipkin/zipkin_core_types.cc
@@ -197,8 +197,8 @@ const zipkin::proto3::Span Span::toProto() const {
   zipkin::proto3::Span span;
   span.set_trace_id(traceIdAsHexString());
   span.set_name(name_);
-  std::cerr << Hex::uint64ToHex(id_) << "\n";
-  span.set_id("1234567890123456");
+  // TODO(dio): generate accordingly.
+  span.set_id(Hex::uint64ToHex(id_).substr(0, 8));
 
   if (parent_id_ && parent_id_.value()) {
     span.set_parent_id(Hex::uint64ToHex(parent_id_.value()));

--- a/source/extensions/tracers/zipkin/zipkin_core_types.cc
+++ b/source/extensions/tracers/zipkin/zipkin_core_types.cc
@@ -31,6 +31,7 @@ Endpoint& Endpoint::operator=(const Endpoint& ep) {
 const zipkin::proto3::Endpoint Endpoint::toProto() const {
   zipkin::proto3::Endpoint endpoint;
   if (!address_) {
+    // TODO(dio): empty string.
     endpoint.set_ipv4("");
     endpoint.set_port(0);
   } else {
@@ -196,7 +197,8 @@ const zipkin::proto3::Span Span::toProto() const {
   zipkin::proto3::Span span;
   span.set_trace_id(traceIdAsHexString());
   span.set_name(name_);
-  span.set_id(Hex::uint64ToHex(id_));
+  std::cerr << Hex::uint64ToHex(id_) << "\n";
+  span.set_id("1234567890123456");
 
   if (parent_id_ && parent_id_.value()) {
     span.set_parent_id(Hex::uint64ToHex(parent_id_.value()));

--- a/source/extensions/tracers/zipkin/zipkin_core_types.h
+++ b/source/extensions/tracers/zipkin/zipkin_core_types.h
@@ -4,6 +4,7 @@
 
 #include "envoy/common/pure.h"
 #include "envoy/common/time.h"
+#include "envoy/config/trace/v2/trace.pb.h"
 #include "envoy/network/address.h"
 
 #include "common/common/hex.h"
@@ -12,6 +13,7 @@
 #include "extensions/tracers/zipkin/util.h"
 
 #include "absl/types/optional.h"
+#include "zipkin.pb.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -33,7 +35,8 @@ public:
    * All classes defining Zipkin abstractions need to implement this method to convert
    * the corresponding abstraction to a Zipkin-compliant JSON.
    */
-  virtual const std::string toJson() PURE;
+  virtual const std::string
+  toJson(const envoy::config::trace::v2::ZipkinConfig::CollectorEndpointVersion version) const PURE;
 };
 
 /**
@@ -91,7 +94,8 @@ public:
    *
    * @return a stringified JSON.
    */
-  const std::string toJson() override;
+  const std::string
+  toJson(const envoy::config::trace::v2::ZipkinConfig::CollectorEndpointVersion version) const override;
 
 private:
   std::string service_name_;
@@ -183,7 +187,8 @@ public:
    *
    * @return a stringified JSON.
    */
-  const std::string toJson() override;
+  const std::string
+  toJson(const envoy::config::trace::v2::ZipkinConfig::CollectorEndpointVersion version) const override;
 
 private:
   uint64_t timestamp_;
@@ -281,7 +286,8 @@ public:
    *
    * @return a stringified JSON.
    */
-  const std::string toJson() override;
+  const std::string
+  toJson(const envoy::config::trace::v2::ZipkinConfig::CollectorEndpointVersion version) const override;
 
 private:
   std::string key_;
@@ -515,7 +521,8 @@ public:
    *
    * @return a stringified JSON.
    */
-  const std::string toJson() override;
+  const std::string
+  toJson(const envoy::config::trace::v2::ZipkinConfig::CollectorEndpointVersion version) const override;
 
   /**
    * Associates a Tracer object with the span. The tracer's reportSpan() method is invoked

--- a/source/extensions/tracers/zipkin/zipkin_core_types.h
+++ b/source/extensions/tracers/zipkin/zipkin_core_types.h
@@ -94,8 +94,10 @@ public:
    *
    * @return a stringified JSON.
    */
-  const std::string
-  toJson(const envoy::config::trace::v2::ZipkinConfig::CollectorEndpointVersion version) const override;
+  const std::string toJson(const envoy::config::trace::v2::ZipkinConfig::CollectorEndpointVersion
+                               version) const override;
+
+  const zipkin::proto3::Endpoint toProto() const;
 
 private:
   std::string service_name_;
@@ -187,8 +189,8 @@ public:
    *
    * @return a stringified JSON.
    */
-  const std::string
-  toJson(const envoy::config::trace::v2::ZipkinConfig::CollectorEndpointVersion version) const override;
+  const std::string toJson(const envoy::config::trace::v2::ZipkinConfig::CollectorEndpointVersion
+                               version) const override;
 
 private:
   uint64_t timestamp_;
@@ -286,8 +288,8 @@ public:
    *
    * @return a stringified JSON.
    */
-  const std::string
-  toJson(const envoy::config::trace::v2::ZipkinConfig::CollectorEndpointVersion version) const override;
+  const std::string toJson(const envoy::config::trace::v2::ZipkinConfig::CollectorEndpointVersion
+                               version) const override;
 
 private:
   std::string key_;
@@ -521,8 +523,8 @@ public:
    *
    * @return a stringified JSON.
    */
-  const std::string
-  toJson(const envoy::config::trace::v2::ZipkinConfig::CollectorEndpointVersion version) const override;
+  const std::string toJson(const envoy::config::trace::v2::ZipkinConfig::CollectorEndpointVersion
+                               version) const override;
 
   /**
    * Associates a Tracer object with the span. The tracer's reportSpan() method is invoked
@@ -563,6 +565,8 @@ public:
    * @param event The annotation's value.
    */
   void log(SystemTime timestamp, const std::string& event);
+
+  const zipkin::proto3::Span toProto() const;
 
 private:
   static const std::string EMPTY_HEX_STRING_;

--- a/source/extensions/tracers/zipkin/zipkin_json_field_names.h
+++ b/source/extensions/tracers/zipkin/zipkin_json_field_names.h
@@ -19,6 +19,9 @@ public:
   const std::string SPAN_DURATION = "duration";
   const std::string SPAN_ANNOTATIONS = "annotations";
   const std::string SPAN_BINARY_ANNOTATIONS = "binaryAnnotations";
+  const std::string SPAN_LOCAL_ENDPOINT = "localEndpoint";
+  const std::string SPAN_REMOTE_ENDPOINT = "remoteEndpoint";
+  const std::string SPAN_TAGS = "tags";
 
   const std::string ANNOTATION_ENDPOINT = "endpoint";
   const std::string ANNOTATION_TIMESTAMP = "timestamp";

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.cc
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.cc
@@ -18,8 +18,7 @@ namespace Extensions {
 namespace Tracers {
 namespace Zipkin {
 
-ZipkinSpan::ZipkinSpan(Zipkin::Span& span, Zipkin::Tracer& tracer, const std::string& version)
-    : span_(span), tracer_(tracer), version_(version) {}
+ZipkinSpan::ZipkinSpan(Zipkin::Span& span, Zipkin::Tracer& tracer) : span_(span), tracer_(tracer) {}
 
 void ZipkinSpan::finishSpan() { span_.finish(); }
 

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
@@ -38,7 +38,7 @@ public:
    *
    * @param span to be wrapped.
    */
-  ZipkinSpan(Zipkin::Span& span, Zipkin::Tracer& tracer, const std::string& version = "v1");
+  ZipkinSpan(Zipkin::Span& span, Zipkin::Tracer& tracer);
 
   /**
    * Calls Zipkin::Span::finishSpan() to perform all actions needed to finalize the span.
@@ -78,7 +78,6 @@ public:
 private:
   Zipkin::Span span_;
   Zipkin::Tracer& tracer_;
-  const std::string version_;
 };
 
 typedef std::unique_ptr<ZipkinSpan> ZipkinSpanPtr;

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
@@ -38,7 +38,7 @@ public:
    *
    * @param span to be wrapped.
    */
-  ZipkinSpan(Zipkin::Span& span, Zipkin::Tracer& tracer);
+  ZipkinSpan(Zipkin::Span& span, Zipkin::Tracer& tracer, const std::string& version = "v1");
 
   /**
    * Calls Zipkin::Span::finishSpan() to perform all actions needed to finalize the span.
@@ -78,6 +78,7 @@ public:
 private:
   Zipkin::Span span_;
   Zipkin::Tracer& tracer_;
+  const std::string version_;
 };
 
 typedef std::unique_ptr<ZipkinSpan> ZipkinSpanPtr;
@@ -162,8 +163,9 @@ public:
    * when making HTTP POST requests carrying spans. This value comes from the
    * Zipkin-related tracing configuration.
    */
-  ReporterImpl(Driver& driver, Event::Dispatcher& dispatcher,
-               const std::string& collector_endpoint);
+  ReporterImpl(Driver& driver, Event::Dispatcher& dispatcher, const std::string& collector_endpoint,
+               const envoy::config::trace::v2::ZipkinConfig::CollectorEndpointVersion
+                   collector_endpoint_version);
 
   /**
    * Implementation of Zipkin::Reporter::reportSpan().
@@ -190,8 +192,10 @@ public:
    *
    * @return Pointer to the newly-created ZipkinReporter.
    */
-  static ReporterPtr NewInstance(Driver& driver, Event::Dispatcher& dispatcher,
-                                 const std::string& collector_endpoint);
+  static ReporterPtr
+  NewInstance(Driver& driver, Event::Dispatcher& dispatcher, const std::string& collector_endpoint,
+              const envoy::config::trace::v2::ZipkinConfig::CollectorEndpointVersion
+                  collector_endpoint_version);
 
 private:
   /**

--- a/test/extensions/tracers/zipkin/config_test.cc
+++ b/test/extensions/tracers/zipkin/config_test.cc
@@ -24,6 +24,7 @@ TEST(ZipkinTracerConfigTest, ZipkinHttpTracer) {
     config:
       collector_cluster: fake_cluster
       collector_endpoint: /api/v1/spans
+      collector_endpoint_version: HTTP_JSON_V1
   )EOF";
 
   envoy::config::trace::v2::Tracing configuration;

--- a/test/extensions/tracers/zipkin/span_buffer_test.cc
+++ b/test/extensions/tracers/zipkin/span_buffer_test.cc
@@ -12,7 +12,7 @@ namespace {
 
 TEST(ZipkinSpanBufferTest, defaultConstructorEndToEnd) {
   DangerousDeprecatedTestTime test_time;
-  SpanBuffer buffer;
+  SpanBuffer buffer(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1);
 
   EXPECT_EQ(0ULL, buffer.pendingSpans());
   EXPECT_EQ("[]", buffer.toStringifiedJsonArray());
@@ -65,7 +65,7 @@ TEST(ZipkinSpanBufferTest, defaultConstructorEndToEnd) {
 
 TEST(ZipkinSpanBufferTest, sizeConstructorEndtoEnd) {
   DangerousDeprecatedTestTime test_time;
-  SpanBuffer buffer(2);
+  SpanBuffer buffer(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1, 2);
 
   EXPECT_EQ(0ULL, buffer.pendingSpans());
   EXPECT_EQ("[]", buffer.toStringifiedJsonArray());

--- a/test/extensions/tracers/zipkin/zipkin_core_types_test.cc
+++ b/test/extensions/tracers/zipkin/zipkin_core_types_test.cc
@@ -19,23 +19,23 @@ TEST(ZipkinCoreTypesEndpointTest, defaultConstructor) {
   Endpoint ep;
 
   EXPECT_EQ("", ep.serviceName());
-  EXPECT_EQ(R"({"ipv4":"","port":0,"serviceName":""})", ep.toJson());
+  EXPECT_EQ(R"({"ipv4":"","port":0,"serviceName":""})", ep.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
 
   Network::Address::InstanceConstSharedPtr addr =
       Network::Utility::parseInternetAddress("127.0.0.1");
   ep.setAddress(addr);
-  EXPECT_EQ(R"({"ipv4":"127.0.0.1","port":0,"serviceName":""})", ep.toJson());
+  EXPECT_EQ(R"({"ipv4":"127.0.0.1","port":0,"serviceName":""})", ep.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
 
   addr = Network::Utility::parseInternetAddressAndPort(
       "[2001:0db8:85a3:0000:0000:8a2e:0370:4444]:7334");
   ep.setAddress(addr);
-  EXPECT_EQ(R"({"ipv6":"2001:db8:85a3::8a2e:370:4444","port":7334,"serviceName":""})", ep.toJson());
+  EXPECT_EQ(R"({"ipv6":"2001:db8:85a3::8a2e:370:4444","port":7334,"serviceName":""})", ep.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
 
   ep.setServiceName("my_service");
   EXPECT_EQ("my_service", ep.serviceName());
 
   EXPECT_EQ(R"({"ipv6":"2001:db8:85a3::8a2e:370:4444","port":7334,"serviceName":"my_service"})",
-            ep.toJson());
+            ep.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
 }
 
 TEST(ZipkinCoreTypesEndpointTest, customConstructor) {
@@ -44,14 +44,14 @@ TEST(ZipkinCoreTypesEndpointTest, customConstructor) {
   Endpoint ep(std::string("my_service"), addr);
 
   EXPECT_EQ("my_service", ep.serviceName());
-  EXPECT_EQ(R"({"ipv4":"127.0.0.1","port":3306,"serviceName":"my_service"})", ep.toJson());
+  EXPECT_EQ(R"({"ipv4":"127.0.0.1","port":3306,"serviceName":"my_service"})", ep.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
 
   addr = Network::Utility::parseInternetAddressAndPort(
       "[2001:0db8:85a3:0000:0000:8a2e:0370:4444]:7334");
   ep.setAddress(addr);
 
   EXPECT_EQ(R"({"ipv6":"2001:db8:85a3::8a2e:370:4444","port":7334,"serviceName":"my_service"})",
-            ep.toJson());
+            ep.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
 }
 
 TEST(ZipkinCoreTypesEndpointTest, copyOperator) {
@@ -61,10 +61,10 @@ TEST(ZipkinCoreTypesEndpointTest, copyOperator) {
   Endpoint ep2(ep1);
 
   EXPECT_EQ("my_service", ep1.serviceName());
-  EXPECT_EQ(R"({"ipv4":"127.0.0.1","port":3306,"serviceName":"my_service"})", ep1.toJson());
+  EXPECT_EQ(R"({"ipv4":"127.0.0.1","port":3306,"serviceName":"my_service"})", ep1.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
 
   EXPECT_EQ(ep1.serviceName(), ep2.serviceName());
-  EXPECT_EQ(ep1.toJson(), ep2.toJson());
+  EXPECT_EQ(ep1.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1), ep2.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
 }
 
 TEST(ZipkinCoreTypesEndpointTest, assignmentOperator) {
@@ -74,10 +74,10 @@ TEST(ZipkinCoreTypesEndpointTest, assignmentOperator) {
   Endpoint ep2 = ep1;
 
   EXPECT_EQ("my_service", ep1.serviceName());
-  EXPECT_EQ(R"({"ipv4":"127.0.0.1","port":3306,"serviceName":"my_service"})", ep1.toJson());
+  EXPECT_EQ(R"({"ipv4":"127.0.0.1","port":3306,"serviceName":"my_service"})", ep1.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
 
   EXPECT_EQ(ep1.serviceName(), ep2.serviceName());
-  EXPECT_EQ(ep1.toJson(), ep2.toJson());
+  EXPECT_EQ(ep1.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1), ep2.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
 }
 
 TEST(ZipkinCoreTypesAnnotationTest, defaultConstructor) {
@@ -99,7 +99,7 @@ TEST(ZipkinCoreTypesAnnotationTest, defaultConstructor) {
 
   std::string expected_json = R"({"timestamp":)" + std::to_string(timestamp) + R"(,"value":")" +
                               ZipkinCoreConstants::get().CLIENT_SEND + R"("})";
-  EXPECT_EQ(expected_json, ann.toJson());
+  EXPECT_EQ(expected_json, ann.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
 
   // Test the copy-semantics flavor of setEndpoint
   Network::Address::InstanceConstSharedPtr addr =
@@ -109,13 +109,13 @@ TEST(ZipkinCoreTypesAnnotationTest, defaultConstructor) {
   EXPECT_TRUE(ann.isSetEndpoint());
   EXPECT_EQ("my_service", ann.endpoint().serviceName());
   EXPECT_EQ(R"({"ipv4":"127.0.0.1","port":3306,"serviceName":"my_service"})",
-            (const_cast<Endpoint&>(ann.endpoint())).toJson());
+            (const_cast<Endpoint&>(ann.endpoint())).toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
 
   expected_json = R"({"timestamp":)" + std::to_string(timestamp) + R"(,"value":")" +
                   ZipkinCoreConstants::get().CLIENT_SEND +
                   R"(","endpoint":{"ipv4":)"
                   R"("127.0.0.1","port":3306,"serviceName":"my_service"}})";
-  EXPECT_EQ(expected_json, ann.toJson());
+  EXPECT_EQ(expected_json, ann.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
 
   // Test the move-semantics flavor of setEndpoint
   addr = Network::Utility::parseInternetAddressAndPort("192.168.1.1:5555");
@@ -124,13 +124,13 @@ TEST(ZipkinCoreTypesAnnotationTest, defaultConstructor) {
   EXPECT_TRUE(ann.isSetEndpoint());
   EXPECT_EQ("my_service_2", ann.endpoint().serviceName());
   EXPECT_EQ(R"({"ipv4":"192.168.1.1","port":5555,"serviceName":"my_service_2"})",
-            (const_cast<Endpoint&>(ann.endpoint())).toJson());
+            (const_cast<Endpoint&>(ann.endpoint())).toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
 
   expected_json = R"({"timestamp":)" + std::to_string(timestamp) + R"(,"value":")" +
                   ZipkinCoreConstants::get().CLIENT_SEND +
                   R"(","endpoint":{"ipv4":"192.168.1.1",)"
                   R"("port":5555,"serviceName":"my_service_2"}})";
-  EXPECT_EQ(expected_json, ann.toJson());
+  EXPECT_EQ(expected_json, ann.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
 
   // Test changeEndpointServiceName
   ann.changeEndpointServiceName("NEW_SERVICE_NAME");
@@ -139,7 +139,7 @@ TEST(ZipkinCoreTypesAnnotationTest, defaultConstructor) {
                   ZipkinCoreConstants::get().CLIENT_SEND +
                   R"(","endpoint":{"ipv4":"192.168.1.1",)"
                   R"("port":5555,"serviceName":"NEW_SERVICE_NAME"}})";
-  EXPECT_EQ(expected_json, ann.toJson());
+  EXPECT_EQ(expected_json, ann.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
 }
 
 TEST(ZipkinCoreTypesAnnotationTest, customConstructor) {
@@ -158,13 +158,13 @@ TEST(ZipkinCoreTypesAnnotationTest, customConstructor) {
 
   EXPECT_EQ("my_service", ann.endpoint().serviceName());
   EXPECT_EQ(R"({"ipv4":"127.0.0.1","port":3306,"serviceName":"my_service"})",
-            (const_cast<Endpoint&>(ann.endpoint())).toJson());
+            (const_cast<Endpoint&>(ann.endpoint())).toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
 
   std::string expected_json = R"({"timestamp":)" + std::to_string(timestamp) + R"(,"value":")" +
                               ZipkinCoreConstants::get().CLIENT_SEND +
                               R"(","endpoint":{"ipv4":"127.0.0.1",)"
                               R"("port":3306,"serviceName":"my_service"}})";
-  EXPECT_EQ(expected_json, ann.toJson());
+  EXPECT_EQ(expected_json, ann.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
 }
 
 TEST(ZipkinCoreTypesAnnotationTest, copyConstructor) {
@@ -181,7 +181,7 @@ TEST(ZipkinCoreTypesAnnotationTest, copyConstructor) {
   EXPECT_EQ(ann.value(), ann2.value());
   EXPECT_EQ(ann.timestamp(), ann2.timestamp());
   EXPECT_EQ(ann.isSetEndpoint(), ann2.isSetEndpoint());
-  EXPECT_EQ(ann.toJson(), ann2.toJson());
+  EXPECT_EQ(ann.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1), ann2.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
   EXPECT_EQ(ann.endpoint().serviceName(), ann2.endpoint().serviceName());
 }
 
@@ -199,7 +199,7 @@ TEST(ZipkinCoreTypesAnnotationTest, assignmentOperator) {
   EXPECT_EQ(ann.value(), ann2.value());
   EXPECT_EQ(ann.timestamp(), ann2.timestamp());
   EXPECT_EQ(ann.isSetEndpoint(), ann2.isSetEndpoint());
-  EXPECT_EQ(ann.toJson(), ann2.toJson());
+  EXPECT_EQ(ann.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1), ann2.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
   EXPECT_EQ(ann.endpoint().serviceName(), ann2.endpoint().serviceName());
 }
 
@@ -218,7 +218,7 @@ TEST(ZipkinCoreTypesBinaryAnnotationTest, defaultConstructor) {
   EXPECT_EQ("value", ann.value());
 
   std::string expected_json = R"({"key":"key","value":"value"})";
-  EXPECT_EQ(expected_json, ann.toJson());
+  EXPECT_EQ(expected_json, ann.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
 
   // Test the copy-semantics flavor of setEndpoint
 
@@ -229,14 +229,14 @@ TEST(ZipkinCoreTypesBinaryAnnotationTest, defaultConstructor) {
   EXPECT_TRUE(ann.isSetEndpoint());
   EXPECT_EQ("my_service", ann.endpoint().serviceName());
   EXPECT_EQ(R"({"ipv4":"127.0.0.1","port":3306,"serviceName":"my_service"})",
-            (const_cast<Endpoint&>(ann.endpoint())).toJson());
+            (const_cast<Endpoint&>(ann.endpoint())).toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
 
   expected_json = "{"
                   R"("key":"key","value":"value",)"
                   R"("endpoint":)"
                   R"({"ipv4":"127.0.0.1","port":3306,"serviceName":"my_service"})"
                   "}";
-  EXPECT_EQ(expected_json, ann.toJson());
+  EXPECT_EQ(expected_json, ann.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
 
   // Test the move-semantics flavor of setEndpoint
   addr = Network::Utility::parseInternetAddressAndPort("192.168.1.1:5555");
@@ -245,13 +245,13 @@ TEST(ZipkinCoreTypesBinaryAnnotationTest, defaultConstructor) {
   EXPECT_TRUE(ann.isSetEndpoint());
   EXPECT_EQ("my_service_2", ann.endpoint().serviceName());
   EXPECT_EQ(R"({"ipv4":"192.168.1.1","port":5555,"serviceName":"my_service_2"})",
-            (const_cast<Endpoint&>(ann.endpoint())).toJson());
+            (const_cast<Endpoint&>(ann.endpoint())).toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
   expected_json = "{"
                   R"("key":"key","value":"value",)"
                   R"("endpoint":)"
                   R"({"ipv4":"192.168.1.1","port":5555,"serviceName":"my_service_2"})"
                   "}";
-  EXPECT_EQ(expected_json, ann.toJson());
+  EXPECT_EQ(expected_json, ann.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
 }
 
 TEST(ZipkinCoreTypesBinaryAnnotationTest, customConstructor) {
@@ -262,7 +262,7 @@ TEST(ZipkinCoreTypesBinaryAnnotationTest, customConstructor) {
   EXPECT_FALSE(ann.isSetEndpoint());
   EXPECT_EQ(AnnotationType::STRING, ann.annotationType());
   std::string expected_json = R"({"key":"key","value":"value"})";
-  EXPECT_EQ(expected_json, ann.toJson());
+  EXPECT_EQ(expected_json, ann.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
 }
 
 TEST(ZipkinCoreTypesBinaryAnnotationTest, copyConstructor) {
@@ -272,7 +272,7 @@ TEST(ZipkinCoreTypesBinaryAnnotationTest, copyConstructor) {
   EXPECT_EQ(ann.value(), ann2.value());
   EXPECT_EQ(ann.key(), ann2.key());
   EXPECT_EQ(ann.isSetEndpoint(), ann2.isSetEndpoint());
-  EXPECT_EQ(ann.toJson(), ann2.toJson());
+  EXPECT_EQ(ann.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1), ann2.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
   EXPECT_EQ(ann.annotationType(), ann2.annotationType());
 }
 
@@ -283,7 +283,7 @@ TEST(ZipkinCoreTypesBinaryAnnotationTest, assignmentOperator) {
   EXPECT_EQ(ann.value(), ann2.value());
   EXPECT_EQ(ann.key(), ann2.key());
   EXPECT_EQ(ann.isSetEndpoint(), ann2.isSetEndpoint());
-  EXPECT_EQ(ann.toJson(), ann2.toJson());
+  EXPECT_EQ(ann.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1), ann2.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
   EXPECT_EQ(ann.annotationType(), ann2.annotationType());
 }
 
@@ -307,7 +307,10 @@ TEST(ZipkinCoreTypesSpanTest, defaultConstructor) {
   EXPECT_FALSE(span.isSetTraceIdHigh());
   EXPECT_EQ(R"({"traceId":"0000000000000000","name":"","id":"0000000000000000",)"
             R"("annotations":[],"binaryAnnotations":[]})",
-            span.toJson());
+            span.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
+  EXPECT_EQ(R"({"traceId":"0000000000000000","name":"","id":"0000000000000000",)"
+            R"("tags":[]})",
+            span.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON));
 
   uint64_t id = Util::generateRandom64(test_time.timeSystem());
   std::string id_hex = Hex::uint64ToHex(id);
@@ -395,7 +398,7 @@ TEST(ZipkinCoreTypesSpanTest, defaultConstructor) {
                 R"({"ipv4":"192.168.1.2","port":3306,"serviceName":"my_service_name"}}],)"
                 R"("binaryAnnotations":[{"key":"lc","value":"my_component_name","endpoint":)"
                 R"({"ipv4":"192.168.1.2","port":3306,"serviceName":"my_service_name"}}]})",
-            span.toJson());
+            span.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
 
   // Test the copy-semantics flavor of addAnnotation and addBinaryAnnotation
 
@@ -446,7 +449,7 @@ TEST(ZipkinCoreTypesSpanTest, defaultConstructor) {
                 R"({"key":"http.return_code","value":"400",)"
                 R"("endpoint":{"ipv4":"192.168.1.2","port":3306,)"
                 R"("serviceName":"my_service_name"}}]})",
-            span.toJson());
+            span.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
 
   // Test setSourceServiceName and setDestinationServiceName
 
@@ -484,7 +487,7 @@ TEST(ZipkinCoreTypesSpanTest, defaultConstructor) {
                 R"({"key":"http.return_code","value":"400",)"
                 R"("endpoint":{"ipv4":"192.168.1.2","port":3306,)"
                 R"("serviceName":"my_service_name"}}]})",
-            span.toJson());
+            span.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
 }
 
 TEST(ZipkinCoreTypesSpanTest, copyConstructor) {

--- a/test/extensions/tracers/zipkin/zipkin_core_types_test.cc
+++ b/test/extensions/tracers/zipkin/zipkin_core_types_test.cc
@@ -19,17 +19,20 @@ TEST(ZipkinCoreTypesEndpointTest, defaultConstructor) {
   Endpoint ep;
 
   EXPECT_EQ("", ep.serviceName());
-  EXPECT_EQ(R"({"ipv4":"","port":0,"serviceName":""})", ep.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
+  EXPECT_EQ(R"({"ipv4":"","port":0,"serviceName":""})",
+            ep.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
 
   Network::Address::InstanceConstSharedPtr addr =
       Network::Utility::parseInternetAddress("127.0.0.1");
   ep.setAddress(addr);
-  EXPECT_EQ(R"({"ipv4":"127.0.0.1","port":0,"serviceName":""})", ep.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
+  EXPECT_EQ(R"({"ipv4":"127.0.0.1","port":0,"serviceName":""})",
+            ep.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
 
   addr = Network::Utility::parseInternetAddressAndPort(
       "[2001:0db8:85a3:0000:0000:8a2e:0370:4444]:7334");
   ep.setAddress(addr);
-  EXPECT_EQ(R"({"ipv6":"2001:db8:85a3::8a2e:370:4444","port":7334,"serviceName":""})", ep.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
+  EXPECT_EQ(R"({"ipv6":"2001:db8:85a3::8a2e:370:4444","port":7334,"serviceName":""})",
+            ep.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
 
   ep.setServiceName("my_service");
   EXPECT_EQ("my_service", ep.serviceName());
@@ -44,7 +47,8 @@ TEST(ZipkinCoreTypesEndpointTest, customConstructor) {
   Endpoint ep(std::string("my_service"), addr);
 
   EXPECT_EQ("my_service", ep.serviceName());
-  EXPECT_EQ(R"({"ipv4":"127.0.0.1","port":3306,"serviceName":"my_service"})", ep.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
+  EXPECT_EQ(R"({"ipv4":"127.0.0.1","port":3306,"serviceName":"my_service"})",
+            ep.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
 
   addr = Network::Utility::parseInternetAddressAndPort(
       "[2001:0db8:85a3:0000:0000:8a2e:0370:4444]:7334");
@@ -61,10 +65,12 @@ TEST(ZipkinCoreTypesEndpointTest, copyOperator) {
   Endpoint ep2(ep1);
 
   EXPECT_EQ("my_service", ep1.serviceName());
-  EXPECT_EQ(R"({"ipv4":"127.0.0.1","port":3306,"serviceName":"my_service"})", ep1.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
+  EXPECT_EQ(R"({"ipv4":"127.0.0.1","port":3306,"serviceName":"my_service"})",
+            ep1.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
 
   EXPECT_EQ(ep1.serviceName(), ep2.serviceName());
-  EXPECT_EQ(ep1.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1), ep2.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
+  EXPECT_EQ(ep1.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1),
+            ep2.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
 }
 
 TEST(ZipkinCoreTypesEndpointTest, assignmentOperator) {
@@ -74,10 +80,12 @@ TEST(ZipkinCoreTypesEndpointTest, assignmentOperator) {
   Endpoint ep2 = ep1;
 
   EXPECT_EQ("my_service", ep1.serviceName());
-  EXPECT_EQ(R"({"ipv4":"127.0.0.1","port":3306,"serviceName":"my_service"})", ep1.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
+  EXPECT_EQ(R"({"ipv4":"127.0.0.1","port":3306,"serviceName":"my_service"})",
+            ep1.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
 
   EXPECT_EQ(ep1.serviceName(), ep2.serviceName());
-  EXPECT_EQ(ep1.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1), ep2.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
+  EXPECT_EQ(ep1.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1),
+            ep2.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
 }
 
 TEST(ZipkinCoreTypesAnnotationTest, defaultConstructor) {
@@ -109,7 +117,8 @@ TEST(ZipkinCoreTypesAnnotationTest, defaultConstructor) {
   EXPECT_TRUE(ann.isSetEndpoint());
   EXPECT_EQ("my_service", ann.endpoint().serviceName());
   EXPECT_EQ(R"({"ipv4":"127.0.0.1","port":3306,"serviceName":"my_service"})",
-            (const_cast<Endpoint&>(ann.endpoint())).toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
+            (const_cast<Endpoint&>(ann.endpoint()))
+                .toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
 
   expected_json = R"({"timestamp":)" + std::to_string(timestamp) + R"(,"value":")" +
                   ZipkinCoreConstants::get().CLIENT_SEND +
@@ -124,7 +133,8 @@ TEST(ZipkinCoreTypesAnnotationTest, defaultConstructor) {
   EXPECT_TRUE(ann.isSetEndpoint());
   EXPECT_EQ("my_service_2", ann.endpoint().serviceName());
   EXPECT_EQ(R"({"ipv4":"192.168.1.1","port":5555,"serviceName":"my_service_2"})",
-            (const_cast<Endpoint&>(ann.endpoint())).toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
+            (const_cast<Endpoint&>(ann.endpoint()))
+                .toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
 
   expected_json = R"({"timestamp":)" + std::to_string(timestamp) + R"(,"value":")" +
                   ZipkinCoreConstants::get().CLIENT_SEND +
@@ -158,7 +168,8 @@ TEST(ZipkinCoreTypesAnnotationTest, customConstructor) {
 
   EXPECT_EQ("my_service", ann.endpoint().serviceName());
   EXPECT_EQ(R"({"ipv4":"127.0.0.1","port":3306,"serviceName":"my_service"})",
-            (const_cast<Endpoint&>(ann.endpoint())).toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
+            (const_cast<Endpoint&>(ann.endpoint()))
+                .toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
 
   std::string expected_json = R"({"timestamp":)" + std::to_string(timestamp) + R"(,"value":")" +
                               ZipkinCoreConstants::get().CLIENT_SEND +
@@ -181,7 +192,8 @@ TEST(ZipkinCoreTypesAnnotationTest, copyConstructor) {
   EXPECT_EQ(ann.value(), ann2.value());
   EXPECT_EQ(ann.timestamp(), ann2.timestamp());
   EXPECT_EQ(ann.isSetEndpoint(), ann2.isSetEndpoint());
-  EXPECT_EQ(ann.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1), ann2.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
+  EXPECT_EQ(ann.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1),
+            ann2.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
   EXPECT_EQ(ann.endpoint().serviceName(), ann2.endpoint().serviceName());
 }
 
@@ -199,7 +211,8 @@ TEST(ZipkinCoreTypesAnnotationTest, assignmentOperator) {
   EXPECT_EQ(ann.value(), ann2.value());
   EXPECT_EQ(ann.timestamp(), ann2.timestamp());
   EXPECT_EQ(ann.isSetEndpoint(), ann2.isSetEndpoint());
-  EXPECT_EQ(ann.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1), ann2.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
+  EXPECT_EQ(ann.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1),
+            ann2.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
   EXPECT_EQ(ann.endpoint().serviceName(), ann2.endpoint().serviceName());
 }
 
@@ -229,7 +242,8 @@ TEST(ZipkinCoreTypesBinaryAnnotationTest, defaultConstructor) {
   EXPECT_TRUE(ann.isSetEndpoint());
   EXPECT_EQ("my_service", ann.endpoint().serviceName());
   EXPECT_EQ(R"({"ipv4":"127.0.0.1","port":3306,"serviceName":"my_service"})",
-            (const_cast<Endpoint&>(ann.endpoint())).toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
+            (const_cast<Endpoint&>(ann.endpoint()))
+                .toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
 
   expected_json = "{"
                   R"("key":"key","value":"value",)"
@@ -245,7 +259,8 @@ TEST(ZipkinCoreTypesBinaryAnnotationTest, defaultConstructor) {
   EXPECT_TRUE(ann.isSetEndpoint());
   EXPECT_EQ("my_service_2", ann.endpoint().serviceName());
   EXPECT_EQ(R"({"ipv4":"192.168.1.1","port":5555,"serviceName":"my_service_2"})",
-            (const_cast<Endpoint&>(ann.endpoint())).toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
+            (const_cast<Endpoint&>(ann.endpoint()))
+                .toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
   expected_json = "{"
                   R"("key":"key","value":"value",)"
                   R"("endpoint":)"
@@ -272,7 +287,8 @@ TEST(ZipkinCoreTypesBinaryAnnotationTest, copyConstructor) {
   EXPECT_EQ(ann.value(), ann2.value());
   EXPECT_EQ(ann.key(), ann2.key());
   EXPECT_EQ(ann.isSetEndpoint(), ann2.isSetEndpoint());
-  EXPECT_EQ(ann.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1), ann2.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
+  EXPECT_EQ(ann.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1),
+            ann2.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
   EXPECT_EQ(ann.annotationType(), ann2.annotationType());
 }
 
@@ -283,7 +299,8 @@ TEST(ZipkinCoreTypesBinaryAnnotationTest, assignmentOperator) {
   EXPECT_EQ(ann.value(), ann2.value());
   EXPECT_EQ(ann.key(), ann2.key());
   EXPECT_EQ(ann.isSetEndpoint(), ann2.isSetEndpoint());
-  EXPECT_EQ(ann.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1), ann2.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
+  EXPECT_EQ(ann.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1),
+            ann2.toJson(envoy::config::trace::v2::ZipkinConfig::HTTP_JSON_V1));
   EXPECT_EQ(ann.annotationType(), ann2.annotationType());
 }
 


### PR DESCRIPTION
This commits enable sending spans in zipkin v2 formats.